### PR TITLE
Adding JOIN

### DIFF
--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -106,9 +106,22 @@ extension MySQLStORM {
 			// SELECT ASSEMBLE
 			var str = "SELECT \(clauseSelectList) FROM \(table()) \(clauseWhere) \(clauseOrder)"
 
-
+            // JOIN
+            var joinsStr = ""
+            for join in joins {
+                switch join.direction {
+                case .INNER:
+                    joinsStr += " INNER JOIN \(join.table) ON \(join.onCondition) "
+                default: ()
+                }
+            }
+            
+            str += joinsStr
+            
 			// TODO: Add joins, having, groupby
-
+            
+            
+            // LIMIT & OFFSET
 			if cursor.limit > 0 {
 				str += " LIMIT \(cursor.limit)"
 			}


### PR DESCRIPTION
This one provides the basic support for INNER JOIN. 

It might be easier as well to adjust `https://github.com/SwiftORM/StORM/blob/master/Sources/StORM/StORMJoins.swift`

and implement `StORMJoinType`  as

```swift
public enum StORMJoinType : String {
	case INNER = "INNER JOIN"
	case OUTER = "OUTER JOIN"
	case LEFT = "LEFT JOIN"
	case RIGHT = "RIGHT JOIN"
	case STRAIGHT = "STRAIGHT_JOIN"
}
```
where this might be helpful to avoid using the `switch` statement and directly access the `.rawValue` of each enum case when building the `JOIN` clause string.  