### PR TITLE
1.0.8

### DIFF
--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -106,9 +106,22 @@ extension MySQLStORM {
 			// SELECT ASSEMBLE
 			var str = "SELECT \(clauseSelectList) FROM \(table()) \(clauseWhere) \(clauseOrder)"
 
-
+            // JOIN
+            var joinsStr = ""
+            for join in joins {
+                switch join.direction {
+                case .INNER:
+                    joinsStr += " INNER JOIN \(join.table) ON \(join.onCondition) "
+                default: ()
+                }
+            }
+            
+            str += joinsStr
+            
 			// TODO: Add joins, having, groupby
-
+            
+            
+            // LIMIT & OFFSET
 			if cursor.limit > 0 {
 				str += " LIMIT \(cursor.limit)"
 			}

--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -94,14 +94,7 @@ extension MySQLStORM {
 			clauseOrder = " ORDER BY \(orderby.joined(separator: ", "))"
 		}
 		do {
-			let getCount = try execRows("SELECT \(clauseCount) FROM \(table()) \(clauseWhere)", params: paramsString)
-			let numrecords = getCount[0].data["counter"]!
-
-			results.cursorData = StORMCursor(
-				limit: cursor.limit,
-				offset: cursor.offset,
-				totalRecords: Int(numrecords as! Int64))
-
+			
             // JOIN
             var joinClause = ""
             for join in joins {
@@ -115,17 +108,34 @@ extension MySQLStORM {
             // SELECT ASSEMBLE
             var str = "SELECT \(clauseSelectList) FROM \(table()) \(joinClause) \(clauseWhere) \(clauseOrder)"
             
+            // SELECT COUNT(*) ASSEMBLE
+            var strCount = "SELECT \(clauseCount) FROM \(table()) \(joinClause) \(clauseWhere) \(clauseOrder)"
+            
+            
 			// TODO: having, groupby
             
             
             // LIMIT & OFFSET
 			if cursor.limit > 0 {
-				str += " LIMIT \(cursor.limit)"
+                let limit = " LIMIT \(cursor.limit)"
+				str += limit
+                strCount += limit
 			}
 			if cursor.offset > 0 {
-				str += " OFFSET \(cursor.offset)"
+                let offset = " OFFSET \(cursor.offset)"
+				str += offset
+                strCount += offset
 			}
 
+            // get the number of records
+            let getCount = try execRows(strCount, params: paramsString)
+            let numrecords = getCount[0].data["counter"]!
+            
+            results.cursorData = StORMCursor(
+                limit: cursor.limit,
+                offset: cursor.offset,
+                totalRecords: Int(numrecords as! Int64))
+            
 			// save results into ResultSet
 			results.rows = try execRows(str, params: paramsString)
 

--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -102,23 +102,20 @@ extension MySQLStORM {
 				offset: cursor.offset,
 				totalRecords: Int(numrecords as! Int64))
 
-
-			// SELECT ASSEMBLE
-			var str = "SELECT \(clauseSelectList) FROM \(table()) \(clauseWhere) \(clauseOrder)"
-
             // JOIN
-            var joinsStr = ""
+            var joinClause = ""
             for join in joins {
                 switch join.direction {
                 case .INNER:
-                    joinsStr += " INNER JOIN \(join.table) ON \(join.onCondition) "
+                    joinClause += " INNER JOIN \(join.table) ON \(join.onCondition) "
                 default: ()
                 }
             }
             
-            str += joinsStr
+            // SELECT ASSEMBLE
+            var str = "SELECT \(clauseSelectList) FROM \(table()) \(joinClause) \(clauseWhere) \(clauseOrder)"
             
-			// TODO: Add joins, having, groupby
+			// TODO: having, groupby
             
             
             // LIMIT & OFFSET


### PR DESCRIPTION
`COUNT(*)` was executing on the wrong query sometimes. The query should be identical in all cases.