### PR TITLE
Fixed compiler warnings for @discardableResult

### DIFF
--- a/Sources/MySQLStORM.swift
+++ b/Sources/MySQLStORM.swift
@@ -200,7 +200,6 @@ open class MySQLStORM: StORM, StORMProtocol {
 	/// Designed as "open" so it can be overriden and customized.
 	/// If an ID has been defined, save() will perform an updae, otherwise a new document is created.
 	/// On error can throw a StORMError error.
-	@discardableResult
 	open func save() throws {
 		do {
 			if keyIsEmpty() {
@@ -220,7 +219,6 @@ open class MySQLStORM: StORM, StORMProtocol {
 	/// Designed as "open" so it can be overriden and customized.
 	/// If an ID has been defined, save() will perform an updae, otherwise a new document is created.
 	/// On error can throw a StORMError error.
-	@discardableResult
 	open func save(set: (_ id: Any)->Void) throws {
 		do {
 			if keyIsEmpty() {
@@ -237,7 +235,6 @@ open class MySQLStORM: StORM, StORMProtocol {
 	}
 
 	/// Unlike the save() methods, create() mandates the addition of a new document, regardless of whether an ID has been set or specified.
-	@discardableResult
 	override open func create() throws {
 		do {
 			try insert(asData())
@@ -249,14 +246,12 @@ open class MySQLStORM: StORM, StORMProtocol {
 
 
 	/// Table Creation (alias for setup)
-	@discardableResult
 	open func setupTable(_ str: String = "") throws {
 		try setup(str)
 	}
 
 	/// Table Creation
 	/// Requires the connection to be configured, as well as a valid "table" property to have been set in the class
-	@discardableResult
 	open func setup(_ str: String = "") throws {
 		LogFile.info("Running setup: \(table())", logFile: "./StORMlog.txt")
 		var createStatement = str

--- a/Sources/SQL.swift
+++ b/Sources/SQL.swift
@@ -14,7 +14,6 @@ import PerfectLogger
 extension MySQLStORM {
 
 	/// Execute Raw SQL (with parameter binding)
-	@discardableResult
 	public func sql(_ statement: String, params: [String]) throws {
 		do {
 			try exec(statement, params: params)


### PR DESCRIPTION
Fixed compiler warnings:

 `@discardableResult declared on a function returning Void is unnecessary`