### PR TITLE
Define MySQL field types for `MySQLStORM` subclass properties

### DIFF
--- a/Sources/MySQLDataType.swift
+++ b/Sources/MySQLDataType.swift
@@ -1,0 +1,104 @@
+//
+//  MySQLDataType.swift
+//  MySQLStORM
+//
+//  Created by Fatih Nayebi on 2018-01-04.
+//
+
+import Foundation
+
+public protocol StORMFieldTypeProtocol {
+    func fieldType() -> String
+}
+
+public enum MySQLDataType: StORMFieldTypeProtocol {
+    case notDefined
+    case bit(length: UInt8)
+    case tinyInt(length: UInt8)
+    case smallInt(length: UInt8)
+    case mediumInt(length: UInt8)
+    case int(length: UInt8)
+    case integer(length: UInt8)
+    case bigInt(length: UInt8)
+    case decimal(length: UInt8, scale: UInt8)
+    case dec(length: UInt8, scale: UInt8)
+    case float(length: UInt8, scale: UInt8)
+    case double(length: UInt8, scale: UInt8)
+    case date
+    case dateTime
+    case timeStamp(fsp: UInt8)
+    case time(fsp: UInt8)
+    case year
+    case char(length: UInt8)
+    case varChar(length: UInt8)
+    case binary(length: UInt8)
+    case varBinary(length: UInt8)
+    case tinyBlob
+    case blob(length: UInt8)
+    case text
+    case mediumBlob
+    case mediumText
+    case longBlob
+    case longText
+    
+    public func fieldType() -> String {
+        switch self {
+        case .notDefined:
+            return "NOT DEFINED"
+        case .bit(let lngt):
+            return "BIT(\(lngt))"
+        case .tinyInt(let lngt):
+            return "TINYINT(\(lngt))"
+        case .smallInt(let lngt):
+            return "SMALLINT(\(lngt))"
+        case .mediumInt(let lngt):
+            return "MEDIUMINT(\(lngt))"
+        case .int(let lngt):
+            return "INT(\(lngt))"
+        case .integer(let lngt):
+            return "INTEGER(\(lngt))"
+        case .bigInt(let lngt):
+            return "BIGINT(\(lngt))"
+        case .decimal(let lngt, let scale):
+            return "DECIMAL(\(lngt),\(scale))"
+        case .dec(let lngt, let scale):
+            return "DEC(\(lngt),\(scale))"
+        case .float(let lngt, let scale):
+            return "FLOAT(\(lngt),\(scale))"
+        case .double(let lngt, let scale):
+            return "DOUBLE(\(lngt),\(scale))"
+        case .date:
+            return "DATE"
+        case .dateTime:
+            return "DATETIME"
+        case .timeStamp(let fsp):
+            return "TIMESTAMP(\(fsp))"
+        case .time(let fsp):
+            return "TIME(\(fsp))"
+        case .year:
+            return "YEAR"
+        case .char(let lngt):
+            return "CHAR(\(lngt))"
+        case .varChar(let lngt):
+            return "VARCHAR(\(lngt))"
+        case .binary(let lngt):
+            return "BINARY(\(lngt))"
+        case .varBinary(let lngt):
+            return "VARBINARY(\(lngt))"
+        case .tinyBlob:
+            return "TINYBLOB"
+        case .blob(let lngt):
+            return "BLOB(\(lngt))"
+        case .text:
+            return "TEXT"
+        case .mediumBlob:
+            return "MEDIUMBLOB"
+        case .mediumText:
+            return "MEDIUMTEXT"
+        case .longBlob:
+            return "LONGBLOB"
+        case .longText:
+            return "LONGTEXT"
+        }
+    }
+}

--- a/Sources/MySQLStORM.swift
+++ b/Sources/MySQLStORM.swift
@@ -17,297 +17,309 @@ import PerfectLogger
 /// MySQLConnector.password = "XXXXXX"
 /// MySQLConnector.port = 3306
 public struct MySQLConnector {
-
-	public static var host: String		= ""
-	public static var username: String	= ""
-	public static var password: String	= ""
-	public static var database: String	= ""
-	public static var port: Int			= 3306
-	public static var charset: String	= "utf8mb4"
-
-	public static var quiet: Bool		= false
-
-	private init(){}
-
+    
+    public static var host: String		= ""
+    public static var username: String	= ""
+    public static var password: String	= ""
+    public static var database: String	= ""
+    public static var port: Int			= 3306
+    public static var charset: String	= "utf8mb4"
+    
+    public static var quiet: Bool		= false
+    
+    private init(){}
+    
 }
 
 
 /// SuperClass that inherits from the foundation "StORM" class.
 /// Provides MySQLL-specific ORM functionality to child classes
 open class MySQLStORM: StORM, StORMProtocol {
-
-	/// Holds the last statement executed
-	public var lastStatement: MySQLStmt?
-
-	/// Table that the child object relates to in the database.
-	/// Defined as "open" as it is meant to be overridden by the child class.
-	open func table() -> String {
-		let m = Mirror(reflecting: self)
-		return ("\(m.subjectType)").lowercased()
-	}
-
-	/// Public init
-	override public init() {
-		super.init()
-	}
-
-	private func printDebug(_ statement: String, _ params: [String]) {
-		if StORMdebug { LogFile.debug("StORM Debug: \(statement) : \(params.joined(separator: ", "))", logFile: "./StORMlog.txt") }
-	}
-
-	// Internal function which executes statements, with parameter binding
-	// Returns raw result
-	@discardableResult
-	func exec(_ statement: String) throws -> MySQL.Results {
-
-		let thisConnection = MySQLConnect(
-			host:		MySQLConnector.host,
-			username:	MySQLConnector.username,
-			password:	MySQLConnector.password,
-			database:	MySQLConnector.database,
-			port:		MySQLConnector.port,
-			charset:	MySQLConnector.charset
-		)
-
-
-
-		thisConnection.open()
-		//		defer { thisConnection.server.close() }
-		thisConnection.statement = statement
-
-		printDebug(statement, [])
-		let querySuccess = thisConnection.server.query(statement: statement)
-
-		guard querySuccess else {
-			throw StORMError.error(thisConnection.server.errorMessage())
-		}
-		let result = thisConnection.server.storeResults()!
-		thisConnection.server.close()
-		return result
-	}
-
-	private func fieldNamesToStringArray(_ arr: [Int:String]) -> [String] {
-		var out = [String]()
-		for i in 0..<arr.count {
-			out.append(arr[i]!)
-		}
-		return out
-	}
-
-	//	@discardableResult
-	func exec(_ statement: String, params: [String], isInsert: Bool = false) throws {
-		let thisConnection = MySQLConnect(
-			host:		MySQLConnector.host,
-			username:	MySQLConnector.username,
-			password:	MySQLConnector.password,
-			database:	MySQLConnector.database,
-			port:		MySQLConnector.port,
-			charset:	MySQLConnector.charset
-		)
-		thisConnection.open()
-		//		defer { thisConnection.server.close() }
-		thisConnection.statement = statement
-
-		lastStatement = MySQLStmt(thisConnection.server)
-		defer { lastStatement?.close() }
-		var res = lastStatement?.prepare(statement: statement)
-		guard res! else {
-			throw StORMError.error(thisConnection.server.errorMessage())
-		}
-
-		for p in params {
-			lastStatement?.bindParam(p)
-		}
-
-		res = lastStatement?.execute()
-		guard res! else {
-			if !MySQLConnector.quiet {
-				print(thisConnection.server.errorMessage())
-				print(thisConnection.server.errorCode())
-			}
-			throw StORMError.error(thisConnection.server.errorMessage())
-		}
-
-		let result = lastStatement?.results()
-		results.foundSetCount = (result?.numRows)!
-		if isInsert {
-			results.insertedID = Int((lastStatement?.insertId())!)
-		}
-		thisConnection.server.close()
-	}
-
-	// Internal function which executes statements, with parameter binding
-	// Returns a processed row set
-	@discardableResult
-	func execRows(_ statement: String, params: [String]) throws -> [StORMRow] {
-		let thisConnection = MySQLConnect(
-			host:		MySQLConnector.host,
-			username:	MySQLConnector.username,
-			password:	MySQLConnector.password,
-			database:	MySQLConnector.database,
-			port:		MySQLConnector.port,
-			charset:	MySQLConnector.charset
-		)
-
-		thisConnection.open()
-		//		defer { thisConnection.server.close() }
-		thisConnection.statement = statement
-
-		printDebug(statement, params)
-
-		lastStatement = MySQLStmt(thisConnection.server)
-		var res = lastStatement?.prepare(statement: statement)
-		guard res! else {
-			throw StORMError.error(thisConnection.server.errorMessage())
-		}
-
-		for p in params {
-			lastStatement?.bindParam(p)
-		}
-
-		res = lastStatement?.execute()
-
-		for index in 0..<Int((lastStatement?.fieldCount())!) {
-			let this = lastStatement?.fieldInfo(index: index)!
-			results.fieldInfo[this!.name] = String(describing: this!.type)
-		}
-
-		guard res! else {
-			throw StORMError.error(thisConnection.server.errorMessage())
-		}
-
-		let result = lastStatement?.results()
-
-		results.foundSetCount = (result?.numRows)!
-		results.fieldNames = fieldNamesToStringArray((lastStatement?.fieldNames())!)
-
-		let resultRows = parseRows(result!, resultSet: results)
-		thisConnection.server.close()
-		return resultRows
-	}
-
-
-	/// Generic "to" function
-	/// Defined as "open" as it is meant to be overridden by the child class.
-	///
-	/// Sample usage:
-	///		id				= this.data["id"] as? Int ?? 0
-	///		firstname		= this.data["firstname"] as? String ?? ""
-	///		lastname		= this.data["lastname"] as? String ?? ""
-	///		email			= this.data["email"] as? String ?? ""
-	open func to(_ this: StORMRow) {
-	}
-
-	/// Generic "makeRow" function
-	/// Defined as "open" as it is meant to be overridden by the child class.
-	open func makeRow() {
-		self.to(self.results.rows[0])
-	}
-
-	/// Standard "Save" function.
-	/// Designed as "open" so it can be overriden and customized.
-	/// If an ID has been defined, save() will perform an updae, otherwise a new document is created.
-	/// On error can throw a StORMError error.
-	open func save() throws {
-		do {
-			if keyIsEmpty() {
-				try insert(asData(1))
-			} else {
-				let (idname, idval) = firstAsKey()
-				try update(data: asData(1), idName: idname, idValue: idval)
-			}
-		} catch {
-			LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
-			throw StORMError.error("\(error)")
-		}
-	}
-
-	/// Alternate "Save" function.
-	/// This save method will use the supplied "set" to assign or otherwise process the returned id.
-	/// Designed as "open" so it can be overriden and customized.
-	/// If an ID has been defined, save() will perform an updae, otherwise a new document is created.
-	/// On error can throw a StORMError error.
-	open func save(set: (_ id: Any)->Void) throws {
-		do {
-			if keyIsEmpty() {
-				let setId = try insert(asData(1))
-				set(setId)
-			} else {
-				let (idname, idval) = firstAsKey()
-				try update(data: asData(1), idName: idname, idValue: idval)
-			}
-		} catch {
-			LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
-			throw StORMError.error("\(error)")
-		}
-	}
-
-	/// Unlike the save() methods, create() mandates the addition of a new document, regardless of whether an ID has been set or specified.
-	override open func create() throws {
-		do {
-			try insert(asData())
-		} catch {
-			LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
-			throw StORMError.error("\(error)")
-		}
-	}
-
-
-	/// Table Creation (alias for setup)
-	open func setupTable(_ str: String = "") throws {
-		try setup(str)
-	}
-
-	/// Table Creation
-	/// Requires the connection to be configured, as well as a valid "table" property to have been set in the class
-	open func setup(_ str: String = "") throws {
-		LogFile.info("Running setup: \(table())", logFile: "./StORMlog.txt")
-		var createStatement = str
-		if str.count == 0 {
-			var opt = [String]()
-			var keyName = ""
-			for child in Mirror(reflecting: self).children {
-				guard let key = child.label else {
-					continue
-				}
-				var verbage = ""
-				if !key.hasPrefix("internal_") && !key.hasPrefix("_") {
-					verbage = "`\(key)` "
-					if child.value is Int && opt.count == 0 {
-						verbage += "int"
-					} else if child.value is Int {
-						verbage += "int"
-					} else if child.value is Bool {
-						verbage += "int" // MySQL has no bool type
-					} else if child.value is Double {
-						verbage += "float"
-					} else if child.value is UInt || child.value is UInt8 || child.value is UInt16 || child.value is UInt32 || child.value is UInt64 {
-						verbage += "blob"
-					} else {
-						verbage += "text"
-					}
-					if opt.count == 0 {
-						if child.value is Int {
-							verbage = "`\(key)` int NOT NULL AUTO_INCREMENT"
-						} else {
-							verbage = "`\(key)` varchar(255) NOT NULL"
-						}
-						keyName = key
-					}
-					opt.append(verbage)
-				}
-			}
-			let keyComponent = ", PRIMARY KEY (`\(keyName)`)"
-
-			createStatement = "CREATE TABLE IF NOT EXISTS \(table()) (\(opt.joined(separator: ", "))\(keyComponent));"
-			if StORMdebug { LogFile.info("createStatement: \(createStatement)", logFile: "./StORMlog.txt") }
-		}
-		do {
-			try sql(createStatement, params: [])
-		} catch {
-			LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
-			throw StORMError.error("\(error)")
-		}
-	}
-	
+    
+    /// Holds the last statement executed
+    public var lastStatement: MySQLStmt?
+    
+    /// Table that the child object relates to in the database.
+    /// Defined as "open" as it is meant to be overridden by the child class.
+    open func table() -> String {
+        let m = Mirror(reflecting: self)
+        return ("\(m.subjectType)").lowercased()
+    }
+    
+    /// Public init
+    override public init() {
+        super.init()
+    }
+    
+    private func printDebug(_ statement: String, _ params: [String]) {
+        if StORMdebug { LogFile.debug("StORM Debug: \(statement) : \(params.joined(separator: ", "))", logFile: "./StORMlog.txt") }
+    }
+    
+    // Internal function which executes statements, with parameter binding
+    // Returns raw result
+    @discardableResult
+    func exec(_ statement: String) throws -> MySQL.Results {
+        
+        let thisConnection = MySQLConnect(
+            host:		MySQLConnector.host,
+            username:	MySQLConnector.username,
+            password:	MySQLConnector.password,
+            database:	MySQLConnector.database,
+            port:		MySQLConnector.port,
+            charset:	MySQLConnector.charset
+        )
+        
+        
+        
+        thisConnection.open()
+        //		defer { thisConnection.server.close() }
+        thisConnection.statement = statement
+        
+        printDebug(statement, [])
+        let querySuccess = thisConnection.server.query(statement: statement)
+        
+        guard querySuccess else {
+            throw StORMError.error(thisConnection.server.errorMessage())
+        }
+        let result = thisConnection.server.storeResults()!
+        thisConnection.server.close()
+        return result
+    }
+    
+    private func fieldNamesToStringArray(_ arr: [Int:String]) -> [String] {
+        var out = [String]()
+        for i in 0..<arr.count {
+            out.append(arr[i]!)
+        }
+        return out
+    }
+    
+    //	@discardableResult
+    func exec(_ statement: String, params: [String], isInsert: Bool = false) throws {
+        let thisConnection = MySQLConnect(
+            host:		MySQLConnector.host,
+            username:	MySQLConnector.username,
+            password:	MySQLConnector.password,
+            database:	MySQLConnector.database,
+            port:		MySQLConnector.port,
+            charset:	MySQLConnector.charset
+        )
+        thisConnection.open()
+        //		defer { thisConnection.server.close() }
+        thisConnection.statement = statement
+        
+        lastStatement = MySQLStmt(thisConnection.server)
+        defer { lastStatement?.close() }
+        var res = lastStatement?.prepare(statement: statement)
+        guard res! else {
+            throw StORMError.error(thisConnection.server.errorMessage())
+        }
+        
+        for p in params {
+            lastStatement?.bindParam(p)
+        }
+        
+        res = lastStatement?.execute()
+        guard res! else {
+            if !MySQLConnector.quiet {
+                print(thisConnection.server.errorMessage())
+                print(thisConnection.server.errorCode())
+            }
+            throw StORMError.error(thisConnection.server.errorMessage())
+        }
+        
+        let result = lastStatement?.results()
+        results.foundSetCount = (result?.numRows)!
+        if isInsert {
+            results.insertedID = Int((lastStatement?.insertId())!)
+        }
+        thisConnection.server.close()
+    }
+    
+    // Internal function which executes statements, with parameter binding
+    // Returns a processed row set
+    @discardableResult
+    func execRows(_ statement: String, params: [String]) throws -> [StORMRow] {
+        let thisConnection = MySQLConnect(
+            host:		MySQLConnector.host,
+            username:	MySQLConnector.username,
+            password:	MySQLConnector.password,
+            database:	MySQLConnector.database,
+            port:		MySQLConnector.port,
+            charset:	MySQLConnector.charset
+        )
+        
+        thisConnection.open()
+        //		defer { thisConnection.server.close() }
+        thisConnection.statement = statement
+        
+        printDebug(statement, params)
+        
+        lastStatement = MySQLStmt(thisConnection.server)
+        var res = lastStatement?.prepare(statement: statement)
+        guard res! else {
+            throw StORMError.error(thisConnection.server.errorMessage())
+        }
+        
+        for p in params {
+            lastStatement?.bindParam(p)
+        }
+        
+        res = lastStatement?.execute()
+        
+        for index in 0..<Int((lastStatement?.fieldCount())!) {
+            let this = lastStatement?.fieldInfo(index: index)!
+            results.fieldInfo[this!.name] = String(describing: this!.type)
+        }
+        
+        guard res! else {
+            throw StORMError.error(thisConnection.server.errorMessage())
+        }
+        
+        let result = lastStatement?.results()
+        
+        results.foundSetCount = (result?.numRows)!
+        results.fieldNames = fieldNamesToStringArray((lastStatement?.fieldNames())!)
+        
+        let resultRows = parseRows(result!, resultSet: results)
+        thisConnection.server.close()
+        return resultRows
+    }
+    
+    
+    /// Generic "to" function
+    /// Defined as "open" as it is meant to be overridden by the child class.
+    ///
+    /// Sample usage:
+    ///		id				= this.data["id"] as? Int ?? 0
+    ///		firstname		= this.data["firstname"] as? String ?? ""
+    ///		lastname		= this.data["lastname"] as? String ?? ""
+    ///		email			= this.data["email"] as? String ?? ""
+    open func to(_ this: StORMRow) {
+    }
+    
+    /// Generic "makeRow" function
+    /// Defined as "open" as it is meant to be overridden by the child class.
+    open func makeRow() {
+        self.to(self.results.rows[0])
+    }
+    
+    /// Standard "Save" function.
+    /// Designed as "open" so it can be overriden and customized.
+    /// If an ID has been defined, save() will perform an updae, otherwise a new document is created.
+    /// On error can throw a StORMError error.
+    open func save() throws {
+        do {
+            if keyIsEmpty() {
+                try insert(asData(1))
+            } else {
+                let (idname, idval) = firstAsKey()
+                try update(data: asData(1), idName: idname, idValue: idval)
+            }
+        } catch {
+            LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
+            throw StORMError.error("\(error)")
+        }
+    }
+    
+    /// Alternate "Save" function.
+    /// This save method will use the supplied "set" to assign or otherwise process the returned id.
+    /// Designed as "open" so it can be overriden and customized.
+    /// If an ID has been defined, save() will perform an updae, otherwise a new document is created.
+    /// On error can throw a StORMError error.
+    open func save(set: (_ id: Any)->Void) throws {
+        do {
+            if keyIsEmpty() {
+                let setId = try insert(asData(1))
+                set(setId)
+            } else {
+                let (idname, idval) = firstAsKey()
+                try update(data: asData(1), idName: idname, idValue: idval)
+            }
+        } catch {
+            LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
+            throw StORMError.error("\(error)")
+        }
+    }
+    
+    /// Unlike the save() methods, create() mandates the addition of a new document, regardless of whether an ID has been set or specified.
+    override open func create() throws {
+        do {
+            try insert(asData())
+        } catch {
+            LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
+            throw StORMError.error("\(error)")
+        }
+    }
+    
+    
+    /// Table Creation (alias for setup)
+    open func setupTable(_ str: String = "") throws {
+        try setup(str)
+    }
+    
+    open subscript(key: String) -> MySQLDataType {
+        get {
+            return .notDefined
+        }
+    }
+ 
+    /// Table Creation
+    /// Requires the connection to be configured, as well as a valid "table" property to have been set in the class
+    /// - Parameter str: create statement
+    /// - Parameter defaultTypes: by default it is true so MySQLStORM decides for the type conversion. To be able to provide your own, you need to override the `subscript(key: String) -> String`
+    open func setup(_ str: String = "", _ useDefaults: Bool? = true) throws {
+        LogFile.info("Running setup: \(table())", logFile: "./StORMlog.txt")
+        var createStatement = str
+        if str.count == 0 {
+            var opt = [String]()
+            var keyName = ""
+            for child in Mirror(reflecting: self).children {
+                guard let key = child.label else {
+                    continue
+                }
+                var verbage = ""
+                if !key.hasPrefix("internal_") && !key.hasPrefix("_") {
+                    verbage = "`\(key)` "
+                    if let defaultTypes = useDefaults, defaultTypes == false {
+                        let field: MySQLDataType = self[key]
+                        verbage += field.fieldType()
+                    } else {
+                        if child.value is Int && opt.count == 0 {
+                            verbage += "int"
+                        } else if child.value is Int {
+                            verbage += "int"
+                        } else if child.value is Bool {
+                            verbage += "int" // MySQL has no bool type
+                        } else if child.value is Double {
+                            verbage += "float"
+                        } else if child.value is UInt || child.value is UInt8 || child.value is UInt16 || child.value is UInt32 || child.value is UInt64 {
+                            verbage += "blob"
+                        } else {
+                            verbage += "text"
+                        }
+                    }
+                    if opt.count == 0 {
+                        if child.value is Int {
+                            verbage = "`\(key)` int NOT NULL AUTO_INCREMENT"
+                        } else {
+                            verbage = "`\(key)` varchar(255) NOT NULL"
+                        }
+                        keyName = key
+                    }
+                    opt.append(verbage)
+                }
+            }
+            let keyComponent = ", PRIMARY KEY (`\(keyName)`)"
+            
+            createStatement = "CREATE TABLE IF NOT EXISTS \(table()) (\(opt.joined(separator: ", "))\(keyComponent));"
+            if StORMdebug { LogFile.info("createStatement: \(createStatement)", logFile: "./StORMlog.txt") }
+        }
+        do {
+            try sql(createStatement, params: [])
+        } catch {
+            LogFile.error("Error msg: \(error)", logFile: "./StORMlog.txt")
+            throw StORMError.error("\(error)")
+        }
+    }
 }


### PR DESCRIPTION
MySQLDataType enum is added that can be used to customize the types for table creation + MySQLStORM setup has been changed to incorporate MySQLDataType