### PR TITLE
Fix could not cast value of type bug

### DIFF
--- a/Sources/Convenience.swift
+++ b/Sources/Convenience.swift
@@ -68,9 +68,9 @@ extension MySQLStORM {
 
 		var paramsString = [String]()
 		var set = [String]()
-		for i in 0..<data.count {
-			paramsString.append(data[i].1 as! String)
-			set.append("\(data[i].0) = ?")
+		for i in data {
+			paramsString.append(String(describing: i.1))
+			set.append("\(i.0) = ?")
 		}
 
 		do {
@@ -89,9 +89,9 @@ extension MySQLStORM {
 
 		var paramsString = [String]()
 		var set = [String]()
-		for i in data.keys {
-			paramsString.append(data[i] as! String)
-			set.append("\(i) = ?")
+		for (key, value) in data {
+			paramsString.append(String(describing: value))
+			set.append("\(key) = ?")
 		}
 
 		do {

--- a/Sources/Insert.swift
+++ b/Sources/Insert.swift
@@ -35,9 +35,9 @@ extension MySQLStORM {
 
 		var keys = [String]()
 		var vals = [String]()
-		for i in data.keys {
-			keys.append(i)
-			vals.append(data[i] as! String)
+		for (key, value) in data {
+			keys.append(key)
+			vals.append(String(describing: value))
 		}
 
 		do {


### PR DESCRIPTION
Could not cast value of type 'Swift.Int' (0x10159c430) to
'Swift.String' (0x10159f6f8).
2018-03-26 14:53:37.098469+0800 iRent[61584:7636991] Could not cast
value of type 'Swift.Int' (0x10159c430) to 'Swift.String' (0x10159f6f8).